### PR TITLE
Update US index constituents for August 2026

### DIFF
--- a/event/us.csv
+++ b/event/us.csv
@@ -130,3 +130,6 @@ event_date,event_type,old_symbol,new_symbol,old_name,new_name,source_url,notes
 2025-07-23,delisting,HES,,Hess Corporation,,https://en.wikipedia.org/wiki/Hess_Corporation,Symbol no longer queryable; removed from SP500 on 2025-07-23.
 2025-12-11,delisting,K,,Kellanova,,https://en.wikipedia.org/wiki/Kellanova,Symbol no longer queryable; removed from SP500 on 2025-12-11.
 2026-02-09,delisting,DAY,,Dayforce,,https://en.wikipedia.org/wiki/Dayforce,Symbol no longer queryable; removed from SP500 on 2026-02-09.
+2026-05-21,ticker_change,BK,BNY,BNY Mellon,BNY,https://www.bny.com/corporate/global/en/about-us/newsroom/press-release/bny-announces-planned-change-of-stock-ticker-symbol-to-bny-130465.html,Ticker changed on NYSE from BK to BNY; historical membership uses the current canonical ticker.
+2026-06-24,ticker_change,SATS,ECHO,EchoStar,EchoStar,https://ir.echostar.com/news-releases/news-release-details/echostar-changing-stocker-ticker-sats-echo-marking-companys-next,Ticker changed on Nasdaq from SATS to ECHO; corporate name unchanged.
+2026-06-29,name_change,HON,,Honeywell International Inc.,Honeywell Technologies Inc.,https://press.spglobal.com/2026-06-23-Alphabet-Set-to-Join-and-Honeywell-International-to-Remain-in-Dow-Jones-Industrial-Average,Honeywell parent renamed after spinning off Honeywell Aerospace; ticker HON remained unchanged.

--- a/history/dow30.csv
+++ b/history/dow30.csv
@@ -28,9 +28,9 @@ GOOGL,Alphabet Inc. (Class A),2026-06-29,
 GS,"The Goldman Sachs Group, Inc.",2013-09-23,
 GT,Goodyear Tire and Rubber Company,1930-07-18,1999-11-01
 HD,"The Home Depot, Inc.",1999-11-01,
-HON,Honeywell International,2003-01-27,2005-11-21
-HON,Honeywell International Inc.,2005-11-21,2008-02-19
-HON,Honeywell International Inc.,2020-08-31,
+HON,Honeywell Technologies Inc.,2003-01-27,2005-11-21
+HON,Honeywell Technologies Inc.,2005-11-21,2008-02-19
+HON,Honeywell Technologies Inc.,2020-08-31,
 HPQ,Hewlett-Packard Company,2002-05-06,2013-09-23
 HWP,Hewlett-Packard Company,1997-03-17,2002-05-06
 IBM,International Business Machines Corporation,1979-06-29,

--- a/history/nasdaq100.csv
+++ b/history/nasdaq100.csv
@@ -66,7 +66,7 @@ CRWD,"CrowdStrike Holdings, Inc. Class A",2021-08-26,
 CRWV,"CoreWeave, Inc.",2026-06-22,
 CSCO,"Cisco Systems, Inc (DE)",2006-01-01,
 CSGP,CoStar Group,2019-12-23,2020-07-20
-CSGP,"CoStar Group, Inc.",2022-12-19,
+CSGP,"CoStar Group, Inc.",2022-12-19,2026-05-18
 CSX,CSX Corporation,2016-02-16,
 CTAS,Cintas,2006-01-01,2010-12-20
 CTAS,Cintas Corporation,2016-12-19,
@@ -86,9 +86,9 @@ DOCU,DocuSign,2020-06-22,2022-12-19
 DTV,DirecTV,2008-04-30,2015-07-24
 DXCM,"DexCom, Inc.",2020-04-20,
 EA,Electronic Arts,2006-01-01,2012-12-24
-EA,Electronic Arts Inc.,2014-12-22,
+EA,Electronic Arts Inc.,2014-12-22,2026-08-04
 EBAY,EBay,2006-01-01,2023-12-18
-ENDP,Endo International,2015-12-21,
+ENDP,Endo International,2015-12-21,2016-07-18
 ENPH,Enphase Energy,2022-11-21,2023-12-18
 EQIX,Equinix,2012-12-24,2015-03-23
 ERIC,LM Ericsson,2006-01-01,2007-12-24
@@ -124,7 +124,8 @@ GRMN,Garmin,2006-01-01,2015-12-21
 HAS,Hasbro,2016-12-19,2019-12-23
 HOLX,Hologic,2007-12-24,2010-12-20
 HOLX,Hologic,2016-12-19,2018-12-24
-HON,Honeywell International Inc.,2021-07-21,
+HON,Honeywell Technologies Inc.,2021-07-21,
+HONA,Honeywell Aerospace,2026-06-29,
 HSIC,Henry Schein,2006-01-01,2019-12-23
 IACI,IAC/InterActiveCorp,2006-01-01,2009-12-21
 IDXX,"IDEXX Laboratories, Inc.",2017-03-20,
@@ -157,6 +158,7 @@ LIFE,Life Technologies,2008-12-22,2013-08-22
 LILA,Liberty Latin America Class A,2015-07-02,2015-12-21
 LILAK,Liberty Latin America Class C,2015-07-02,2015-12-21
 LIN,Linde plc Ordinary Shares,2024-03-18,
+LITE,Lumentum Holdings Inc.,2026-05-18,
 LLTC,Linear Technology,2006-01-01,2016-10-19
 LMCA,Liberty Media,2012-12-24,2013-01-15
 LMCA,Liberty Media,2013-06-05,2016-06-20
@@ -203,7 +205,7 @@ NTAP,NetApp,2018-12-24,2020-08-24
 NTES,NetEase,2016-03-16,2022-12-19
 NUAN,Nuance Communications,2011-12-19,2013-12-23
 NVDA,NVIDIA Corporation,2006-01-01,
-NWSA,News Corporation Class A,2009-01-20,
+NWSA,News Corporation Class A,2009-01-20,2013-06-28
 NXPI,NXP Semiconductors,2013-12-23,2017-02-07
 NXPI,NXP Semiconductors N.V,2018-11-05,
 ODFL,"Old Dominion Freight Line, Inc.",2022-01-24,
@@ -250,6 +252,7 @@ SNDK,SanDisk,2006-01-01,2008-12-22
 SNDK,SanDisk,2009-12-21,2016-03-16
 SNDK,Sandisk Corporation,2026-04-20,
 SNPS,"Synopsys, Inc.",2017-12-18,
+SPCX,Space Exploration Technologies Corporation,2026-07-07,
 SOLS,Solstice Advanced Materials,2025-10-30,2025-11-06
 SPLK,Splunk,2019-12-23,2022-12-19
 SPLK,Splunk,2023-12-18,2024-03-18
@@ -297,7 +300,6 @@ WDAY,"Workday, Inc. Class A",2017-12-18,
 WDC,Western Digital,2012-12-24,2020-10-19
 WDC,Western Digital Corporation,2025-12-22,
 WFM,Whole Foods Market,2006-01-01,2016-12-19
-WLTW,Willis Towers Watson,2018-12-24,
 WMT,Walmart Inc.,2026-01-20,
 WTW,Willis Towers Watson,2006-01-01,2020-04-30
 WYNN,Wynn Resorts,2006-01-01,2015-12-21

--- a/history/sp500.csv
+++ b/history/sp500.csv
@@ -109,7 +109,6 @@ BIG,Big Lots,1976-07-01,2013-02-15
 BIIB,Biogen,2003-11-13,
 BIO,Bio-Rad Laboratories,2020-06-22,2024-09-23
 BJS,BJ Services,1976-07-01,2010-04-29
-BK,BNY Mellon,1995-03-31,
 BKNG,Booking Holdings,2009-11-03,
 BKR,Baker Hughes,2017-07-07,
 BLDR,Builders FirstSource,2023-12-18,
@@ -118,6 +117,7 @@ BMC,BMC Software,1976-07-01,2013-09-10
 BMS,Bemis Company,1976-07-01,2014-12-05
 BMS,Bemis,2019-06-07,2019-06-11
 BMY,Bristol Myers Squibb,1957-03-04,
+BNY,BNY,1995-03-31,
 BR,Broadridge Financial Solutions,2018-06-18,
 BRCM,Broadcom Corporation,1976-07-01,2016-02-01
 BRK.B,Berkshire Hathaway,2010-02-16,
@@ -132,7 +132,7 @@ BXLT,Baxalta,2015-07-01,2016-06-03
 BXP,"BXP, Inc.",2006-04-03,
 C,Citigroup,1988-05-31,
 CA,CA Technologies,1976-07-01,2018-11-06
-CAG,Conagra Brands,1983-08-31,
+CAG,Conagra Brands,1983-08-31,2026-06-30
 CAH,Cardinal Health,1997-05-27,
 CAM,Cameron International,1976-07-01,2016-04-04
 CARR,Carrier Global,2020-04-03,
@@ -210,7 +210,7 @@ CSRA,CSRA,2015-12-01,2018-04-04
 CSX,CSX Corporation,1957-03-04,
 CTAS,Cintas,2001-03-01,
 CTLT,Catalent,2020-09-21,2024-12-23
-CTRA,Coterra,2008-06-23,
+CTRA,Coterra,2008-06-23,2026-05-07
 CTSH,Cognizant,2006-11-17,
 CTVA,Corteva,2019-06-03,
 CTX,Centex Corp.,1976-07-01,2009-08-19
@@ -268,8 +268,9 @@ DWDP,DuPont,2017-09-01,2019-06-03
 DXC,DXC Technology,2017-04-04,2023-10-03
 DXCM,Dexcom,2020-05-12,
 DYN,Dynegy,1976-07-01,2009-12-18
-EA,Electronic Arts,2002-07-22,
+EA,Electronic Arts,2002-07-22,2026-08-05
 EBAY,eBay Inc.,2002-07-22,
+ECHO,EchoStar,2026-03-23,
 ECL,Ecolab,1989-01-31,
 ED,Consolidated Edison,1957-03-04,
 EFX,Equifax,1997-06-19,
@@ -319,12 +320,13 @@ FDS,FactSet,2021-12-20,
 FDX,FedEx,1980-12-31,
 FDXF,FedEx Freight,2026-06-02,
 FE,FirstEnergy,1997-11-28,
+FERG,Ferguson Enterprises,2026-08-05,
 FFIV,"F5, Inc.",2010-12-20,
 FHN,First Horizon,1976-07-01,2013-06-21
 FICO,Fair Isaac,2023-03-20,
 FII,Federated Investors,1976-07-01,2013-01-02
 FIS,Fidelity National Information Services,2006-11-10,
-FISV,Fiserv,2001-04-02,2025-11-11
+FISV,Fiserv,2001-04-02,
 FITB,Fifth Third Bancorp,1996-03-29,
 FIX,Comfort Systems USA,2025-12-22,
 FL,Foot Locker,2016-04-04,2019-08-09
@@ -398,7 +400,8 @@ HNG,Houston Natural Gas,1976-07-01,1976-07-01
 HNZ,Heinz,1976-07-01,2013-06-06
 HOG,Harley-Davidson,1976-07-01,2020-06-22
 HOLX,Hologic,2016-03-30,2026-04-09
-HON,Honeywell,1957-03-04,
+HON,Honeywell Technologies Inc.,1957-03-04,
+HONA,Honeywell Aerospace,2026-06-29,
 HOOD,Robinhood Markets,2025-09-22,
 HOT,Starwood,1976-07-01,2016-09-22
 HP,Helmerich & Payne,2010-02-26,2020-05-22
@@ -696,7 +699,6 @@ RVTY,Revvity,1985-05-31,
 RX,IMS Health,1976-07-01,2010-02-26
 S,Sprint Nextel,1976-07-01,2013-07-08
 SAI,SAIC,2009-12-18,2013-09-20
-SATS,EchoStar,2026-03-23,
 SBAC,SBA Communications,2017-09-01,
 SBL,Symbol Technologies,2000-12-05,2007-01-10
 SBNY,Signature Bank,2021-12-20,2023-03-15
@@ -819,6 +821,7 @@ USB,U.S. Bancorp,1999-11-01,
 USL,USLife,1976-07-01,1997-06-17
 V,Visa Inc.,2009-12-21,
 VAR,Varian Medical Systems,1976-07-01,2021-04-20
+VEEV,Veeva Systems,2026-05-07,
 VFC,VF Corporation,1976-07-01,2024-04-03
 VIAB,Viacom,1976-07-01,2019-12-05
 VICI,Vici Properties,2022-06-08,

--- a/latest/dow30.csv
+++ b/latest/dow30.csv
@@ -12,7 +12,7 @@ DIS,Disney,1991-05-06
 GOOGL,Alphabet,2026-06-29
 GS,Goldman Sachs,2013-09-23
 HD,Home Depot,1999-11-01
-HON,Honeywell,2020-08-31
+HON,Honeywell Technologies Inc.,2020-08-31
 IBM,IBM,1979-06-29
 JNJ,Johnson & Johnson,1997-03-17
 JPM,JPMorgan Chase,1991-05-06

--- a/latest/nasdaq100.csv
+++ b/latest/nasdaq100.csv
@@ -28,13 +28,11 @@ CPRT,"Copart, Inc. (DE)",2019-12-23
 CRWD,"CrowdStrike Holdings, Inc. Class A",2021-08-26
 CRWV,"CoreWeave, Inc.",2026-06-22
 CSCO,"Cisco Systems, Inc. (DE)",2006-01-01
-CSGP,"CoStar Group, Inc.",2022-12-19
 CSX,CSX Corporation,2016-02-16
 CTAS,Cintas Corporation,2016-12-19
 DASH,"DoorDash, Inc. Class A",2023-12-18
 DDOG,"Datadog, Inc. Class A",2021-12-20
 DXCM,"DexCom, Inc.",2020-04-20
-EA,Electronic Arts Inc.,2014-12-22
 EXC,Exelon Corporation,2019-11-21
 FANG,"Diamondback Energy, Inc.",2022-12-19
 FAST,Fastenal Company,2006-01-01
@@ -44,7 +42,8 @@ GEHC,GE HealthCare Technologies Inc.,2023-06-07
 GILD,"Gilead Sciences, Inc.",2006-01-01
 GOOG,Alphabet Inc. Class C Capital Stock,2014-04-03
 GOOGL,Alphabet Inc. Class A,2006-01-01
-HON,Honeywell International Inc.,2021-07-21
+HON,Honeywell Technologies Inc.,2021-07-21
+HONA,Honeywell Aerospace,2026-06-29
 IDXX,"IDEXX Laboratories, Inc.",2017-03-20
 INTC,Intel Corporation,2006-01-01
 INTU,Intuit Inc.,2006-01-01
@@ -53,6 +52,7 @@ KDP,Keurig Dr Pepper Inc.,2020-10-19
 KHC,The Kraft Heinz Company,2015-07-02
 KLAC,KLA Corporation,2016-12-19
 LIN,Linde plc Ordinary Shares,2024-03-18
+LITE,Lumentum Holdings Inc.,2026-05-18
 LRCX,Lam Research Corporation,2014-12-22
 MAR,Marriott International Class A,2013-11-18
 MCHP,Microchip Technology Incorporated,2016-07-18
@@ -87,6 +87,7 @@ SBUX,Starbucks Corporation,2006-01-01
 SHOP,Shopify Inc. Class A Subordinate Voting Shares,2025-05-19
 SNDK,Sandisk Corporation,2026-04-20
 SNPS,"Synopsys, Inc.",2017-12-18
+SPCX,Space Exploration Technologies Corporation,2026-07-07
 STX,Seagate Technology Holdings PLC Ordinary Shares (Ireland),2025-12-22
 TER,"Teradyne, Inc.",2026-06-22
 TMUS,"T-Mobile US, Inc.",2015-12-21

--- a/latest/sp500.csv
+++ b/latest/sp500.csv
@@ -60,12 +60,12 @@ BEN,Franklin Resources,1998-04-30
 BF.B,Brown–Forman,1982-10-31
 BG,Bunge Global,2023-03-15
 BIIB,Biogen,2003-11-13
-BK,BNY Mellon,1995-03-31
 BKNG,Booking Holdings,2009-11-03
 BKR,Baker Hughes,2017-07-07
 BLDR,Builders FirstSource,2023-12-18
 BLK,BlackRock,2011-04-04
 BMY,Bristol Myers Squibb,1957-03-04
+BNY,BNY,1995-03-31
 BR,Broadridge Financial Solutions,2018-06-18
 BRK.B,Berkshire Hathaway,2010-02-16
 BRO,Brown & Brown,2021-09-20
@@ -73,7 +73,6 @@ BSX,Boston Scientific,1995-02-24
 BX,Blackstone Inc.,2023-09-18
 BXP,"BXP, Inc.",2006-04-03
 C,Citigroup,1988-05-31
-CAG,Conagra Brands,1983-08-31
 CAH,Cardinal Health,1997-05-27
 CARR,Carrier Global,2020-04-03
 CASY,Casey's,2026-04-09
@@ -121,7 +120,6 @@ CSCO,Cisco,1993-12-01
 CSGP,CoStar Group,2022-09-19
 CSX,CSX Corporation,1957-03-04
 CTAS,Cintas,2001-03-01
-CTRA,Coterra,2008-06-23
 CTSH,Cognizant,2006-11-17
 CTVA,Corteva,2019-06-03
 CVNA,Carvana,2025-12-22
@@ -152,8 +150,8 @@ DUK,Duke Energy,1976-06-30
 DVA,DaVita,2008-07-31
 DVN,Devon Energy,2000-08-30
 DXCM,Dexcom,2020-05-12
-EA,Electronic Arts,2002-07-22
 EBAY,eBay Inc.,2002-07-22
+ECHO,EchoStar,2026-03-23
 ECL,Ecolab,1989-01-31
 ED,Consolidated Edison,1957-03-04
 EFX,Equifax,1997-06-19
@@ -187,6 +185,7 @@ FDS,FactSet,2021-12-20
 FDX,FedEx,1980-12-31
 FDXF,FedEx Freight,2026-06-02
 FE,FirstEnergy,1997-11-28
+FERG,Ferguson Enterprises,2026-08-05
 FFIV,"F5, Inc.",2010-12-20
 FICO,Fair Isaac,2023-03-20
 FIS,Fidelity National Information Services,2006-11-10
@@ -227,7 +226,8 @@ HD,Home Depot (The),1988-03-31
 HIG,Hartford (The),1957-03-04
 HII,Huntington Ingalls Industries,2018-01-03
 HLT,Hilton Worldwide,2017-06-19
-HON,Honeywell,1957-03-04
+HON,Honeywell Technologies Inc.,1957-03-04
+HONA,Honeywell Aerospace,2026-06-29
 HOOD,Robinhood Markets,2025-09-22
 HPE,Hewlett Packard Enterprise,2015-11-02
 HPQ,HP Inc.,1974-12-31
@@ -399,7 +399,6 @@ ROST,Ross Stores,2009-12-21
 RSG,Republic Services,2008-12-05
 RTX,RTX Corporation,1957-03-04
 RVTY,Revvity,1985-05-31
-SATS,EchoStar,2026-03-23
 SBAC,SBA Communications,2017-09-01
 SBUX,Starbucks,2000-06-07
 SCHW,Charles Schwab Corporation,1997-06-02
@@ -465,6 +464,7 @@ UPS,United Parcel Service,2002-07-22
 URI,United Rentals,2014-09-20
 USB,U.S. Bancorp,1999-11-01
 V,Visa Inc.,2009-12-21
+VEEV,Veeva Systems,2026-05-07
 VICI,Vici Properties,2022-06-08
 VLO,Valero Energy,2002-12-20
 VLTO,Veralto,2023-10-02

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "index-constitution"
-version = "0.6.2"
+version = "0.6.3"
 description = "Point-in-time and current constituents for major stock indices (CSI 300, CSI 500, S&P 500, NASDAQ-100), packaged as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- sync Nasdaq-100, S&P 500, and Dow 30 latest/history data through August 9, 2026
- canonicalize BK to BNY, SATS to ECHO, and Honeywell Technologies naming while recording the corresponding events
- close stale history intervals and bump the package version to 0.6.3

## Validation

- live constituent audit: Nasdaq-100 102/102, S&P 500 503/503, Dow 30 30/30; no latest/history or web-set differences
- focused API tests: 13 passed
- package build: `uv build`
- artifact check: `twine check` passed for wheel and sdist
- full suite: 23 passed, 1 pre-existing failure in `test_cn_merger_events` for the unrelated CSI 300 event data