### PR TITLE
Release version 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "index-constitution"
-version = "0.6.4"
+version = "1.0.0"
 description = "Point-in-time and current constituents for major stock indices (CSI 300, CSI 500, S&P 500, NASDAQ-100), packaged as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- promote index-constitution to the stable 1.0.0 release
- publish the fully audited CSI 300, CSI 500, S&P 500, Nasdaq-100, and Dow 30 datasets
- include the monthly index update agent workflow merged in the release baseline

## Validation

- `uv run pytest -q`: 26 passed
- `uv build`: 1.0.0 wheel and source distribution built successfully
- `twine check`: both artifacts passed
- release diff contains only the package version change